### PR TITLE
Fix README model name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # 3d-models
-Collection of 3D models generated with OpenAI o1 Pro using the Blender Python API  
+Collection of 3D models generated with OpenAI o1 Pro using the Blender Python API
 
 ## Adding a model within a visionOS RealityView
 ```


### PR DESCRIPTION
## Summary
- revert README to say **o1 Pro**, addressing feedback that it wasn't a typo

## Testing
- `git status --short`
